### PR TITLE
Add Multiselect shortcuts

### DIFF
--- a/src/Listbox.tsx
+++ b/src/Listbox.tsx
@@ -32,6 +32,7 @@ type State = {
   buttonId: string | null,
   optionIds: Array<[string, string]>,
   optionRefs: Array<[string, HTMLElement]>,
+  lastSelected: string | null;
 }
 
 export class Listbox extends Component<Props, State> {
@@ -50,6 +51,7 @@ export class Listbox extends Component<Props, State> {
       buttonId: null,
       optionIds: [],
       optionRefs: [],
+      lastSelected: null,
     }
   }
 
@@ -131,6 +133,14 @@ export class Listbox extends Component<Props, State> {
         this.close()
       })
     }
+
+    this.setState({ lastSelected: value })
+  }
+
+  selectMany = (values: string[]): void => {
+    if (this.props.multiselect) {
+      this.props.onChange(this.sortByValues([...values, ...this.props.values]))
+    }
   }
   
   sortByValues(values: string[]): string[] {
@@ -174,6 +184,7 @@ export class Listbox extends Component<Props, State> {
       open: this.open,
       close: this.close,
       select: this.select,
+      selectMany: this.selectMany,
       focus: this.focus,
       clearTypeahead: this.clearTypeahead,
       typeahead: this.state.typeahead,
@@ -182,6 +193,7 @@ export class Listbox extends Component<Props, State> {
       setListboxButtonRef: this.setListboxButtonRef,
       listboxButtonRef: this.state.listboxButtonRef,
       listboxListRef: this.state.listboxListRef,
+      lastSelected: this.state.lastSelected,
       isOpen: this.state.isOpen,
       activeItem: this.state.activeItem,
       setActiveItem: this.setActiveItem,

--- a/src/ListboxList.tsx
+++ b/src/ListboxList.tsx
@@ -87,14 +87,14 @@ export class ListboxList extends Component<Props, State> {
       e.preventDefault()
       if (this.context.typeahead !== "") {
         this.context.type(" ")
-      } else if (!e.shiftKey) {
-        this.context.select(this.context.activeItem || this.context.props)
-      } else {
+      } else if (e.shiftKey && this.context.props.multiselect) {
         const lastIndex = this.context.values.indexOf(this.context.lastSelected)
         const activeIndex = this.context.values.indexOf(this.context.activeItem)
 
         const toSelect = lastIndex > activeIndex ? this.context.values.slice(activeIndex, lastIndex) : this.context.values.slice(lastIndex + 1, activeIndex + 1)
         this.context.selectMany(toSelect)
+      } else {
+        this.context.select(this.context.activeItem || this.context.props)
       }
       break
     case "Enter":

--- a/src/ListboxList.tsx
+++ b/src/ListboxList.tsx
@@ -30,7 +30,9 @@ export class ListboxList extends Component<Props, State> {
 
   handleBlur = (e: React.FocusEvent): void => {
     if (e.relatedTarget === this.context.listboxButtonRef){ return } // The button will already handle the toggle for us
-    this.context.close()
+    if (!this.context.props.multiselect) {
+      this.context.close()
+    }
   }
 
   handleKeydown = (e: React.KeyboardEvent): void => {
@@ -85,8 +87,14 @@ export class ListboxList extends Component<Props, State> {
       e.preventDefault()
       if (this.context.typeahead !== "") {
         this.context.type(" ")
-      } else {
+      } else if (!e.shiftKey) {
         this.context.select(this.context.activeItem || this.context.props)
+      } else {
+        const lastIndex = this.context.values.indexOf(this.context.lastSelected)
+        const activeIndex = this.context.values.indexOf(this.context.activeItem)
+
+        const toSelect = lastIndex > activeIndex ? this.context.values.slice(activeIndex, lastIndex) : this.context.values.slice(lastIndex + 1, activeIndex + 1)
+        this.context.selectMany(toSelect)
       }
       break
     case "Enter":

--- a/src/ListboxList.tsx
+++ b/src/ListboxList.tsx
@@ -37,7 +37,6 @@ export class ListboxList extends Component<Props, State> {
     const focusedIndex = this.state.values?.indexOf(this.context.activeItem)
     // focusedIndex is -1 if this.context.activeItem  is not in this.state.values
     if (focusedIndex === -1 || !this.state.values){ return }
-
     let indexToFocus
     switch (e.key) {
     case "Esc":
@@ -63,6 +62,10 @@ export class ListboxList extends Component<Props, State> {
       if (focusedIndex || focusedIndex === 0){ // Typescript makes us check this.
         indexToFocus = focusedIndex - 1 < 0 ? this.state.values?.length - 1 : focusedIndex - 1
         this.context.focus(this.state.values[indexToFocus])
+
+        if (this.context.props.multiselect && e.shiftKey) {
+          this.context.select(this.state.values[indexToFocus])
+        }
       }
       break
     case "Down":
@@ -71,6 +74,10 @@ export class ListboxList extends Component<Props, State> {
       if (focusedIndex || focusedIndex === 0){ // Typescript makes us check this.
         indexToFocus = focusedIndex + 1 > this.state.values?.length - 1 ? 0 : focusedIndex + 1
         this.context.focus(this.state.values[indexToFocus])
+
+        if (this.context.props.multiselect && e.shiftKey) {
+          this.context.select(this.state.values[indexToFocus])
+        }
       }
       break
     case "Spacebar":

--- a/test/multiselect.test.tsx
+++ b/test/multiselect.test.tsx
@@ -16,7 +16,7 @@ describe("given listbox is determined by isOpen", () => {
   })
   
   const onChange = jest.fn()
-  const optionValues = ["item0", "item1", "item2", "item3"]
+  const optionValues = ["item0", "item1", "item2", "item3", "item4"]
   const value = ["item2"]
   
   describe("by default", () => {
@@ -57,10 +57,12 @@ describe("given listbox is determined by isOpen", () => {
     })
 
     describe("when clicking on an option", () => {
-      it("then calls onChange with values ordered based on options", () => {
+      beforeEach(() => {
         const item0 = screen.getByText("Item 0")
         userEvent.click(item0)
-        
+      })
+      
+      it("then calls onChange with values ordered based on options", () => {
         expect(onChange).toHaveBeenCalledWith(["item0", "item2"])
       })
 
@@ -69,7 +71,7 @@ describe("given listbox is determined by isOpen", () => {
       })
     })
 
-    describe("when shift", () => {
+    describe("when pressing shift", () => {
       describe.each(["Down", "ArrowDown"])("and %i", (key) => {
         it("then selects the next value", () => {
           fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
@@ -81,6 +83,32 @@ describe("given listbox is determined by isOpen", () => {
         it("then selects the next value", () => {
           fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
           expect(onChange).toHaveBeenCalledWith(["item1", "item2"])
+        })
+      })
+
+      describe.each(["Spacebar"])("and %i", (key) => {
+        describe("When moving up", () => {
+          const keyArrow = "ArrowUp"
+          
+          it("then selects contiguous items from the most recently selected item to the focused item ", () => {
+            userEvent.click(screen.getByText("Item 4"))
+            fireEvent.keyDown(screen.getByRole("listbox"), { key: keyArrow })
+            fireEvent.keyDown(screen.getByRole("listbox"), { key: keyArrow })
+            fireEvent.keyDown(screen.getByRole("listbox"), { key: keyArrow })
+            fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
+            expect(onChange).toHaveBeenCalledWith(["item1", "item2", "item3"])
+          })
+        })
+
+        describe("When moving down", () => {
+          const keyArrow = "ArrowDown"
+          it("then selects contiguous items from the most recently selected item to the focused item ", () => {
+            userEvent.click(screen.getByText("Item 2 (selected) (active)"))
+            fireEvent.keyDown(screen.getByRole("listbox"), { key: keyArrow })
+            fireEvent.keyDown(screen.getByRole("listbox"), { key: keyArrow })
+            fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
+            expect(onChange).toHaveBeenCalledWith(["item2", "item3", "item4"])
+          })
         })
       })
     })
@@ -109,6 +137,7 @@ function setup({ onChange, optionValues, value }: Setup) {
             <ListboxOption value={optionValues[1]}>{innerOption("Item 1")}</ListboxOption>
             <ListboxOption value={optionValues[2]}>{innerOption("Item 2")}</ListboxOption>
             <ListboxOption value={optionValues[3]}>{innerOption("Item 3")}</ListboxOption>
+            <ListboxOption value={optionValues[4]}>{innerOption("Item 4")}</ListboxOption>
           </ListboxList>}
         </>
       )}

--- a/test/multiselect.test.tsx
+++ b/test/multiselect.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import userEvent from "@testing-library/user-event"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import {
   Listbox,
   ListboxButton,
@@ -66,6 +66,22 @@ describe("given listbox is determined by isOpen", () => {
 
       it("then does NOT close the list", () => {
         expect(screen.queryByRole("listbox")).toBeInTheDocument()
+      })
+    })
+
+    describe("when shift", () => {
+      describe.each(["Down", "ArrowDown"])("and %i", (key) => {
+        it("then selects the next value", () => {
+          fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
+          expect(onChange).toHaveBeenCalledWith(["item2", "item3"])
+        })
+      })
+
+      describe.each(["Up", "ArrowUp"])("and %i", (key) => {
+        it("then selects the next value", () => {
+          fireEvent.keyDown(screen.getByRole("listbox"), { key, shiftKey: true })
+          expect(onChange).toHaveBeenCalledWith(["item1", "item2"])
+        })
       })
     })
   })


### PR DESCRIPTION
These changes include:

* Shift + Down Arrow: Moves focus to and toggles the selected state of the next option.
* Shift + Up Arrow: Moves focus to and toggles the selected state of the previous option.
* Shift + Space: Selects contiguous items from the most recently selected item to the focused item.